### PR TITLE
add hw1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# vladargunov platform
-vladargunov Platform repository
+# Домашнее задание 1
+
+1. Почему все pod в namespace kube-system восстановились после удаления?
+
+- Почему восстанавливается под `coredns`?
+
+Под `coredns` контролируется объектом `deployment`, который всегда проверяет необходимое кол-во реплик и при необходимости воссоздает их.
+
+- Почему восстанавливаются остальные под из `kube-system`?
+
+Остальные поды принадлежат к категории Static Pods, которые управляются напрямую kubelet и [воссоздаются им при необходимости](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/). Для справки, данные поды могут быть удалены если их конфигурации также будут удалены из директории `/etc/kubernetes/manifests`.
+
+2. Добавлен [web-pod.yml](/kubernetes-intro/web-pod.yaml) контейнер.
+
+3. Добавлены файлы [frontend-pod.yaml](/kubernetes-intro/frontend-pod.yaml) и [frontend-pod-healthy.yaml](/kubernetes-intro/frontend-pod-healthy.yaml).
+
+Проблема автосгенерированного `yaml` файла заключалась в отсутствии переменных окружения.
+
+---

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: vladargunov/microservices-frontend:0.0.1
+    name: frontend
+    resources: {}
+    env:
+      - name: PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: "productcatalogservice:3550"
+      - name: CURRENCY_SERVICE_ADDR
+        value: "currencyservice:7000"
+      - name: CART_SERVICE_ADDR
+        value: "cartservice:7070"
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: "recommendationservice:8080"
+      - name: SHIPPING_SERVICE_ADDR
+        value: "shippingservice:50051"
+      - name: CHECKOUT_SERVICE_ADDR
+        value: "checkoutservice:5050"
+      - name: AD_SERVICE_ADDR
+        value: "adservice:9555"
+      # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
+      # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp
+      # - name: ENV_PLATFORM
+      #   value: "aws"
+      - name: ENABLE_PROFILER
+        value: "0"
+      # - name: CYMBAL_BRANDING
+      #   value: "true"
+      # - name: FRONTEND_MESSAGE
+      #   value: "Replace this with a message you want to display on all pages."
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: vladargunov/microservices-frontend:0.0.1
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+    - name: web
+      image: vladargunov/nginx-otus:0.0.1
+      volumeMounts:
+         - name: app
+           mountPath: /app
+  initContainers:
+    - name: init
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+         - name: app
+           mountPath: /app
+
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:centos7
+RUN  mkdir /app/
+RUN yum -y install epel-release
+RUN yum -y install nginx
+RUN usermod -u 1001 nginx && groupmod -g 1001 nginx
+COPY nginx.conf /etc/nginx/nginx.conf
+EXPOSE 8000
+CMD ["nginx"]

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,27 @@
+daemon            off;
+worker_processes  2;
+
+events {
+    use           epoll;
+    worker_connections  128;
+}
+
+http {
+    server_tokens off;
+    include       mime.types;
+    charset       utf-8;
+
+    server {
+        server_name   localhost;
+        listen        8000;
+
+        error_page    500 502 503 504  /50x.html;
+
+        location      / {
+            root      /app;
+            index index.html;
+        }
+
+    }
+
+}


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 
Ответ на вопрос 1: Почему все pod в namespace kube-system восстановились после удаления?
- Почему восстанавливается под `coredns`?

Под `coredns` контролируется объектом `deployment`, который всегда проверяет необходимое кол-во реплик и при необходимости воссоздает их.

- Почему восстанавливаются остальные под из `kube-system`?

Остальные поды принадлежат к категории Static Pods, которые управляются напрямую kubelet и [воссоздаются им при необходимости](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/). Для справки, данные поды могут быть удалены если их конфигурации также будут удалены из директории `/etc/kubernetes/manifests`.

- Добавлен [web-pod.yml](/kubernetes-intro/web-pod.yaml) контейнер.
- Добавлены файлы [frontend-pod.yaml](/kubernetes-intro/frontend-pod.yaml) и [frontend-pod-healthy.yaml](/kubernetes-intro/frontend-pod-healthy.yaml).

Проблема автосгенерированного `yaml` файла заключалась в отсутствии переменных окружения.

## Как запустить проект:
 - Применить написанные манифесты

```
kubectl apply -f web-pod.yaml

kubectl apply -f frontend-pod-healthy.yaml
```

## Как проверить работоспособность:
 - Форварднуть порт с `web-pod.yaml`
```
kubectl port-forward --address 0.0.0.0 pod/web 8000:8000
```
Проверить что страница отображается на 127.0.0.1:8000.


## PR checklist:
 - [x] Выставлен label с темой домашнего задания
